### PR TITLE
nec: increase tolerances for bit pulses

### DIFF
--- a/src/protocol/nec/decoder.rs
+++ b/src/protocol/nec/decoder.rs
@@ -24,7 +24,7 @@ const fn pulselens<Cmd: NecCommandVariant>() -> [u32; 8] {
     ]
 }
 
-const TOL: [u32; 8] = [7, 7, 5, 5, 0, 0, 0, 0];
+const TOL: [u32; 8] = [7, 7, 25, 12, 0, 0, 0, 0];
 
 impl<Mono: InfraMonotonic, Cmd: NecCommandVariant> DecoderBuilder<Mono> for Nec<Cmd> {
     type Decoder = NecDecoder<Mono, Cmd>;


### PR DESCRIPTION
The default 5% tolerance on the low bit pulses only ends up with a 56us slack. With the combination of a sloppy/cheap remote and a micro running at a low frequency (attiny @ 1hmz) it's quite easy to not recognize a pulse.

Looking at the implementation in linux, that uses a margin of half a unit (560us), while also tracking both the low and high pulses.

Up the tolerances to be roughly half a unit, which makes the recognition of signals much more reliable.